### PR TITLE
improvement: replace auto-sync with notice

### DIFF
--- a/lib/mix/tasks/usage_rules.install.ex
+++ b/lib/mix/tasks/usage_rules.install.ex
@@ -44,22 +44,16 @@ if Code.ensure_loaded?(Igniter) do
 
     @impl Igniter.Mix.Task
     def igniter(igniter) do
-      file =
-        Enum.find(
-          ["AGENTS.md", "CLAUDE.md", "RULES.md", "rules.md", "cursorrules", "rules"],
-          "AGENTS.md",
-          &Igniter.exists?(igniter, &1)
-        )
-
       igniter
-      |> Igniter.compose_task("usage_rules.sync", [
-        file,
-        "--all",
-        "--link-to-folder",
-        "deps",
-        "--inline",
-        "usage_rules:all"
-      ])
+      |> Igniter.add_notice("""
+        `usage_rules` is installed!
+
+        Example sync commands:
+        - `mix usage_rules.sync AGENTS.md --all --link-to-folder rules --inline usage_rules:all`
+        - `mix usage_rules.sync RULES.md --all`
+
+        For more info and examples: `mix help usage_rules.sync`
+        """)
     end
   end
 else


### PR DESCRIPTION
See issue #11 

Old code automatically ran `mix usage_rules.sync` after install, forcing the developer to delete AGENTS.md and re-sync.

New code eliminates the auto-sync, and instead emits a notice with example commands.

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
