### PR TITLE
Add critical warning about %{} pattern matching

### DIFF
--- a/usage-rules/elixir.md
+++ b/usage-rules/elixir.md
@@ -3,6 +3,7 @@
 ## Pattern Matching
 - Use pattern matching over conditional logic when possible
 - Prefer to match on function heads instead of using `if`/`else` or `case` in function bodies
+- **CRITICAL**: `%{}` matches ANY map, not just empty maps. Use `map_size(map) == 0` guard to check for truly empty maps
 
 ## Error Handling
 - Use `{:ok, result}` and `{:error, reason}` tuples for operations that can fail


### PR DESCRIPTION
## Summary
- Add warning that `%{}` matches any map, not just empty maps
- Recommend using `map_size(map) == 0` guard for true empty map detection

Fixes #21