### PR TITLE
Use single line for skill description

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,18 +68,12 @@ defp usage_rules do
       build: [
         "ash-framework": [
           # The description tells people how to use this skill.
-          description: \"""
-          Use this skill working with Ash Framework or any of its extensions. 
-          Always consult this when making any domain changes, features or fixes.
-          \""",
+          description: "Use this skill working with Ash Framework or any of its extensions. Always consult this when making any domain changes, features or fixes.",
           # Include all Ash dependencies
           usage_rules: [:ash, ~r/^ash_/]
         ],
         "phoenix-framework": [
-          description: \"""
-          Use this skill working with Phoenix Framework.
-          Consult this when working with the web layer, controllers, views, liveviews etc.
-          \""",
+          description: "Use this skill working with Phoenix Framework. Consult this when working with the web layer, controllers, views, liveviews etc.",
           # Include all Phoenix dependencies
           usage_rules: [:phoenix, ~r/^phoenix_/]
         ]


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [x] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

This is just to show a workaround when using skills coming from usage_rules inside claude code. I think claude code has a bug discovering project-scoped sklls with a description field that is multi-line.