### PR TITLE
chore: sort discovered deps for stable ordering across environments

### DIFF
--- a/lib/mix/tasks/usage_rules.sync.ex
+++ b/lib/mix/tasks/usage_rules.sync.ex
@@ -297,7 +297,7 @@ if Code.ensure_loaded?(Igniter) do
         |> Enum.map(fn {dep, path} -> {dep, Path.relative_to_cwd(path)} end)
 
       igniter_deps = get_deps_from_igniter(igniter)
-      (mix_deps ++ igniter_deps) |> Enum.uniq()
+      (mix_deps ++ igniter_deps) |> Enum.uniq() |> Enum.sort_by(&elem(&1, 0))
     end
 
     defp get_deps_from_igniter(igniter) do

--- a/test/mix/tasks/usage_rules.sync_test.exs
+++ b/test/mix/tasks/usage_rules.sync_test.exs
@@ -393,6 +393,26 @@ defmodule Mix.Tasks.UsageRules.SyncTest do
       assert content =~ "Ash Ecto"
       refute content =~ "Ash Testing"
     end
+
+    test "regex produces sections in stable sorted order" do
+      igniter =
+        project_with_deps(%{
+          "deps/zeta/usage-rules.md" => "# Zeta Rules",
+          "deps/alpha/usage-rules.md" => "# Alpha Rules",
+          "deps/mango/usage-rules.md" => "# Mango Rules"
+        })
+        |> sync(file: "AGENTS.md", usage_rules: [~r/./])
+        |> assert_creates("AGENTS.md")
+
+      content = file_content(igniter, "AGENTS.md")
+
+      alpha_pos = :binary.match(content, "## alpha usage") |> elem(0)
+      mango_pos = :binary.match(content, "## mango usage") |> elem(0)
+      zeta_pos = :binary.match(content, "## zeta usage") |> elem(0)
+
+      assert alpha_pos < mango_pos
+      assert mango_pos < zeta_pos
+    end
   end
 
   describe "per-dep link option" do


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

# Problem

Different environments (machines, Elixir versions) running `mix usage_rules.sync` can produce different output for the same config. This causes unnecessary diffs and noisy commits when collaborators sync on their own machines.

The root cause is `discover_deps/1` returning deps from `Mix.Project.deps_paths()` (a Map) without sorting. Since Erlang Map iteration order is not guaranteed, regex-matched deps in `usage_rules` config can appear in different orders.

| Config style | Ordering |
|---|---|
| Explicit atoms (`:ash`) | Stable (config order) |
| Regex (`~r/^ash_/`) | **Unstable** (Map order dependent) |
| Sub-rules | Stable (`Enum.sort` already applied) |

# Solution

Add `Enum.sort_by(&elem(&1, 0))` to the end of `discover_deps/1` so that `all_deps` is always in alphabetical order. This makes regex matching produce deterministic results without affecting explicit atom ordering (which is handled in `resolve_usage_rules`).

## Notes

The test verifies the intended sorted order but cannot reproduce the non-deterministic behavior in test mode, since Erlang small maps (<=32 keys) store keys in sorted order internally.