### PR TITLE
feat: support options for :all in usage_rules config

### DIFF
--- a/test/mix/tasks/usage_rules.sync_test.exs
+++ b/test/mix/tasks/usage_rules.sync_test.exs
@@ -92,6 +92,34 @@ defmodule Mix.Tasks.UsageRules.SyncTest do
       refute content =~ "no_rules"
     end
 
+    test "syncs with {:all, link: :markdown} generates markdown links for all packages" do
+      igniter =
+        project_with_deps(%{
+          "deps/foo/usage-rules.md" => "# Foo Rules",
+          "deps/bar/usage-rules.md" => "# Bar Rules"
+        })
+        |> sync(file: "AGENTS.md", usage_rules: {:all, link: :markdown})
+        |> assert_creates("AGENTS.md")
+
+      content = file_content(igniter, "AGENTS.md")
+      assert content =~ "[bar usage rules](deps/bar/usage-rules.md)"
+      assert content =~ "[foo usage rules](deps/foo/usage-rules.md)"
+    end
+
+    test "syncs with {:all, link: :at} generates @ links for all packages" do
+      igniter =
+        project_with_deps(%{
+          "deps/foo/usage-rules.md" => "# Foo Rules",
+          "deps/bar/usage-rules.md" => "# Bar Rules"
+        })
+        |> sync(file: "AGENTS.md", usage_rules: {:all, link: :at})
+        |> assert_creates("AGENTS.md")
+
+      content = file_content(igniter, "AGENTS.md")
+      assert content =~ "@deps/bar/usage-rules.md"
+      assert content =~ "@deps/foo/usage-rules.md"
+    end
+
     test "errors when a package is not a dependency" do
       project_with_deps(%{
         "deps/foo/usage-rules.md" => "# Foo Rules"


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [x] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

#3 Problem

`:all` in `usage_rules` config discovers all deps with usage rules, but it cannot accept options like `link: :markdown`.

# Solution

Support `{:all, opts}` tuple syntax, consistent with existing patterns:

```elixir
usage_rules: [
  file: "AGENTS.md",
  usage_rules: {:all, link: :markdown}
]