### PR TITLE
Fix documentation retrieval for callbacks

### DIFF
--- a/lib/mix/tasks/usage_rules.docs.ex
+++ b/lib/mix/tasks/usage_rules.docs.ex
@@ -63,7 +63,29 @@ defmodule Mix.Tasks.UsageRules.Docs do
             quote do
               require IEx.Helpers
 
-              IEx.Helpers.h(unquote(quoted))
+              original_gl = Process.group_leader()
+              {:ok, cap} = StringIO.open("")
+              Process.group_leader(self(), cap)
+
+              try do
+                IEx.Helpers.h(unquote(quoted))
+                {_, output} = StringIO.contents(cap)
+
+                # Use regex with case insensitivity to detect the hint about callbacks
+                if String.match?(
+                     output,
+                     ~r/No documentation for function #{Regex.escape(unquote(module))} was found,.*callback.*same name/i
+                   ) do
+                  Process.group_leader(self(), original_gl)
+                  IEx.Helpers.b(unquote(quoted))
+                else
+                  Process.group_leader(self(), original_gl)
+                  IO.write(output)
+                end
+              after
+                Process.group_leader(self(), original_gl)
+                StringIO.close(cap)
+              end
             end
           )
       end

--- a/test/mix/tasks/usage_rules.docs_test.exs
+++ b/test/mix/tasks/usage_rules.docs_test.exs
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2025 usage_rules contributors <https://github.com/ash-project/usage_rules/graphs/contributors>
+#
+# SPDX-License-Identifier: MIT
+
+defmodule Mix.Tasks.UsageRules.DocsTest do
+  use ExUnit.Case
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.UsageRules.Docs
+
+  defp strip_ansi(string) do
+    String.replace(string, ~r/\e\[[0-9;]*m/, "")
+  end
+
+  test "shows documentation for a module" do
+    output =
+      capture_io(fn ->
+        Docs.run(["Enum"])
+      end)
+      |> strip_ansi()
+
+    assert output =~ "Searching local docs for"
+    assert output =~ "Enum"
+    assert output =~ "Functions for working with collections"
+  end
+
+  test "shows documentation for a function" do
+    output =
+      capture_io(fn ->
+        Docs.run(["Enum.map/2"])
+      end)
+      |> strip_ansi()
+
+    assert output =~ "Searching local docs for"
+    assert output =~ "Enum.map/2"
+    assert output =~ "Returns a list where each element is the result of invoking"
+  end
+
+  test "shows documentation for a callback" do
+    output =
+      capture_io(fn ->
+        Docs.run(["GenServer.handle_call"])
+      end)
+      |> strip_ansi()
+
+    assert output =~ "Searching local docs for"
+    assert output =~ "GenServer.handle_call"
+    assert output =~ "Invoked to handle synchronous"
+    refute output =~ "No documentation for function GenServer.handle_call was found"
+  end
+
+  test "handles invalid expressions" do
+    assert_raise Mix.Error, ~r/Invalid module or function/, fn ->
+      Docs.run(["invalid expression"])
+    end
+  end
+
+  test "handles non-existent modules" do
+    output =
+      capture_io(fn ->
+        Docs.run(["NonExistentModule"])
+      end)
+
+    assert output =~ "Could not load module NonExistentModule"
+  end
+end


### PR DESCRIPTION
Current `mix usage_rules.docs` does not return doc for callback, it only works for module/function using the `IEx.Helpers.h/1` function.

```sh
usage_rules % mix usage_rules.docs GenServer.handle_call                                             [0]
Compiling 1 file (.ex)
Generated usage_rules app
Searching local docs for 

    GenServer.handle_call

Use `mix usage_rules.search_docs` to search online documentation for more results.


No documentation for function GenServer.handle_call was found, but there is a callback with the same name.
You can view callback documentation with the b/1 helper.
```
This PR:

- Improve callback detection in usage_rules.docs task using robust regex
- Add comprehensive tests for the docs task covering modules, functions, and callbacks

```sh
usage_rules % mix usage_rules.docs GenServer.handle_call                                             [3]
Searching local docs for 

    GenServer.handle_call

Use `mix usage_rules.search_docs` to search online documentation for more results.


@callback handle_call(request :: term(), from(), state :: term()) ::
            {:reply, reply, new_state}
            | {:reply, reply, new_state,
               timeout() | :hibernate | {:continue, continue_arg :: term()}}
            | {:noreply, new_state}
            | {:noreply, new_state,
               timeout() | :hibernate | {:continue, continue_arg :: term()}}
            | {:stop, reason, reply, new_state}
            | {:stop, reason, new_state}
          when reply: term(), new_state: term(), reason: term()

Invoked to handle synchronous call/3 messages. call/3 will block until a reply
is received (unless the call times out or nodes are disconnected).

request is the request message sent by a call/3, from is a 2-tuple containing
the caller's PID and a term that uniquely identifies the call, and state is the
current state of the GenServer.
...
```

# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [X] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [X] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [X] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
