### PR TITLE
fix: filter out deps without usage rules in skills.build

### DIFF
--- a/lib/mix/tasks/usage_rules.sync.ex
+++ b/lib/mix/tasks/usage_rules.sync.ex
@@ -333,7 +333,8 @@ if Code.ensure_loaded?(Igniter) do
       if igniter.assigns[:test_mode?] do
         igniter.rewrite.sources
         |> Enum.filter(fn {path, _source} ->
-          String.match?(path, ~r|^deps/[^/]+/usage-rules\.md$|) ||
+          String.match?(path, ~r|^deps/[^/]+/mix\.exs$|) ||
+            String.match?(path, ~r|^deps/[^/]+/usage-rules\.md$|) ||
             String.match?(path, ~r|^deps/[^/]+/usage-rules/[^/]+\.md$|) ||
             String.match?(path, ~r|^deps/[^/]+/usage-rules/skills/[^/]+/SKILL\.md$|) ||
             String.match?(path, ~r|^deps/[^/]+/usage-rules/skills/[^/]+/.+$|)
@@ -353,12 +354,16 @@ if Code.ensure_loaded?(Igniter) do
     defp get_packages_with_usage_rules(igniter, all_deps) do
       Enum.filter(all_deps, fn
         {_name, path} when is_binary(path) and path != "" ->
-          Igniter.exists?(igniter, Path.join(path, "usage-rules.md")) ||
-            Igniter.exists?(igniter, Path.join(path, "usage-rules"))
+          package_has_usage_rules?(igniter, path)
 
         _ ->
           false
       end)
+    end
+
+    defp package_has_usage_rules?(igniter, package_path) do
+      Igniter.exists?(igniter, Path.join(package_path, "usage-rules.md")) ||
+        Enum.any?(find_available_sub_rules(igniter, package_path))
     end
 
     # -------------------------------------------------------------------
@@ -801,7 +806,12 @@ if Code.ensure_loaded?(Igniter) do
       custom_description = skill_opts[:description]
 
       # Resolve which packages to include in this skill (supports atoms and regexes)
-      resolved_packages = expand_dep_specs(usage_rule_specs, all_deps)
+      resolved_packages =
+        usage_rule_specs
+        |> expand_dep_specs(all_deps)
+        |> Enum.filter(fn {_pkg_name, package_path, _mode} ->
+          package_has_usage_rules?(igniter, package_path)
+        end)
 
       if Enum.any?(resolved_packages) do
         generate_built_skill(

--- a/test/mix/tasks/usage_rules.sync_test.exs
+++ b/test/mix/tasks/usage_rules.sync_test.exs
@@ -928,6 +928,36 @@ defmodule Mix.Tasks.UsageRules.SyncTest do
       refute content =~ "Req"
     end
 
+    test "regex build skips deps without usage rules when rendering references and search docs" do
+      igniter =
+        project_with_deps(%{
+          "deps/phoenix/usage-rules/ecto.md" => "# Phoenix Ecto",
+          "deps/phoenix/usage-rules/liveview.md" => "# Phoenix LiveView",
+          "deps/phoenix_ecto/mix.exs" => "defmodule PhoenixEcto.MixProject, do: nil",
+          "deps/phoenix_html/mix.exs" => "defmodule PhoenixHTML.MixProject, do: nil"
+        })
+        |> sync(
+          skills: [
+            location: ".claude/skills",
+            build: [
+              "phoenix-framework": [usage_rules: [:phoenix, ~r/^phoenix_/]]
+            ]
+          ]
+        )
+        |> assert_creates(".claude/skills/phoenix-framework/SKILL.md")
+        |> assert_creates(".claude/skills/phoenix-framework/references/ecto.md")
+        |> assert_creates(".claude/skills/phoenix-framework/references/liveview.md")
+
+      content = file_content(igniter, ".claude/skills/phoenix-framework/SKILL.md")
+
+      assert content =~ "[ecto](references/ecto.md)"
+      assert content =~ "[liveview](references/liveview.md)"
+      refute content =~ "references/phoenix_ecto.md"
+      refute content =~ "references/phoenix_html.md"
+      refute content =~ "-p phoenix_ecto"
+      refute content =~ "-p phoenix_html"
+    end
+
     test "removes stale managed skills no longer in build list" do
       stale_skill_md =
         "---\nname: use-old\nmetadata:\n  managed-by: usage-rules\n---\n\n<!-- usage-rules-skill-start -->\nOld skill.\n<!-- usage-rules-skill-end -->"


### PR DESCRIPTION
# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [x] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies

I followed the "build" example from the docs noticed a bunch of packages being included that matched the regex but don't contain usage rules (eg. phoenix_ecto, phoenix_html, etc). This change verifies the packages do include usage rules.