### PR TITLE
fix: compile before search_docs HTTP lookups in mix projects

### DIFF
--- a/lib/mix/tasks/usage_rules.search_docs.ex
+++ b/lib/mix/tasks/usage_rules.search_docs.ex
@@ -43,6 +43,10 @@ defmodule Mix.Tasks.UsageRules.SearchDocs do
 
   @impl true
   def run(args) do
+    if Mix.Project.get() do
+      loadpaths!()
+    end
+
     {:ok, _} = Application.ensure_all_started(:req)
     {opts, args} = OptionParser.parse!(args, strict: @switches, aliases: @aliases)
     opts = Keyword.put(opts, :mix_project, !!Mix.Project.get())
@@ -432,6 +436,19 @@ defmodule Mix.Tasks.UsageRules.SearchDocs do
   rescue
     _ ->
       false
+  end
+
+  defp loadpaths! do
+    args = [
+      "--no-elixir-version-check",
+      "--no-deps-check",
+      "--no-archives-check",
+      "--no-listeners"
+    ]
+
+    Mix.Task.run("loadpaths", args)
+    Mix.Task.reenable("loadpaths")
+    Mix.Task.reenable("deps.loadpaths")
   end
 
   @spec raise_bad_args!() :: no_return()


### PR DESCRIPTION
Does not seem to hurt, and solved my issue in a complex Mix setup. See commit message for details.


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
