### PR TITLE
docs: add tip on writing effective skill descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ defp usage_rules do
 end
 ```
 
+> **Tip:** Many AI coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf) use the `description:` value to decide when to auto-load the skill without manual invocation. Descriptions with specific, observable signals tend to work better than generic topic labels — e.g. `"Load when any file uses Ash.Resource or when debugging Ash.Error.Forbidden"` rather than `"Use when working with Ash resources."` File paths, error type names, and mix task names give agents precise matching cues.
+
 Then run:
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds a blockquote tip immediately after the `description:` field in the `build:` config sample in README.md
- Explains that AI coding agents (Claude Code, Cursor, GitHub Copilot, Windsurf) use the `description:` value for auto-loading skills
- Encourages specific, observable signals over generic topic labels, with concrete examples

## Contributor Checklist

- [x] Docs-only change — no code modified
- [x] README change placed directly after the `description:` field in the `build:` config sample
- [x] `mix compile` passes
- [x] `mix credo` passes (0 issues)

## AI Policy

I acknowledge that AI tooling was used in preparing this contribution.

## Notes

No issue to close — this is a standalone documentation improvement. Per the repo's CONTRIBUTING guidance, small docs-only changes are fine as direct PRs.