### PR TITLE
Remove Logger requirement from usage_rules task

### DIFF
--- a/lib/mix/tasks/usage_rules.docs.ex
+++ b/lib/mix/tasks/usage_rules.docs.ex
@@ -22,8 +22,6 @@ defmodule Mix.Tasks.UsageRules.Docs do
       $ mix usage_rules.docs MyApp.User.Helpers
   """
 
-  require Logger
-
   @impl true
   def run([module = <<first, _::binary>>]) when first in ?A..?Z or first == ?: do
     loadpaths!()


### PR DESCRIPTION
Avoid this warning:
```
==> usage_rules
Compiling 5 files (.ex)
    warning: unused require Logger
    │
 25 │   require Logger
    │   ~
    │
    └─ lib/mix/tasks/usage_rules.docs.ex:25:3
```


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [x] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
